### PR TITLE
Update start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "uninstall": "0.0.0"
   },
   "scripts": {
-    "start": "export REACT_APP_STAGE=dev&&react-scripts start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",


### PR DESCRIPTION
There is no need to set dev environment specifically to `dev` for start script since by default if that key is not provided, app's going to work as its dev.